### PR TITLE
[Bug] [UI] - misalignment of password field on show password symbol button click #32

### DIFF
--- a/src/main/resources/login/login_form.fxml
+++ b/src/main/resources/login/login_form.fxml
@@ -43,7 +43,7 @@
          </font>
       </Label>
 
-      <PasswordField fx:id="password" layoutX="85.0" layoutY="289.0" prefHeight="30.0" prefWidth="235.0" promptText="Enter password" style="-fx-background-color: white;" />
+      <PasswordField fx:id="password" layoutX="85.0" layoutY="290.0" prefHeight="30.0" prefWidth="235.0" promptText="Enter password" style="-fx-background-color: white;" />
 
       <TextField fx:id="visiblePassword" layoutX="85.0" layoutY="290.0" prefHeight="30.0" prefWidth="235.0" style="-fx-background-color: white;" visible="false" />
 


### PR DESCRIPTION
##Title:
[Bug] [UI] - misalignment of password field on show password symbol button click


## 🧐 Because  

"This PR fixes a critical UI bug where the password field is not aligned with the text field when password is shown."


## 🛠 This PR  
 fixed the alignment of the submit button


## 🔗 Issue  

Closes #32    


## 📚 Documentation  

https://github.com/user-attachments/assets/4c9b9136-75e1-45c5-8176-9831ff7226a8


