### PR TITLE
Responsive Tab Pane

### DIFF
--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -11,7 +11,6 @@
 <?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Line?>
@@ -244,13 +243,13 @@
                   </Button>
                </children>
             </StackPane>
-            <Pane>
+            <VBox>
                <children>
-                  <TabPane nodeOrientation="LEFT_TO_RIGHT" tabClosingPolicy="UNAVAILABLE">
+                  <TabPane nodeOrientation="LEFT_TO_RIGHT" prefHeight="1000.0" tabClosingPolicy="UNAVAILABLE">
                     <tabs>
                       <Tab text="Untitled Tab 1">
                         <content>
-                          <AnchorPane prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: #081028;" />
+                          <AnchorPane prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: pink;" />
                         </content>
                       </Tab>
                       <Tab text="Untitled Tab 2">
@@ -261,7 +260,7 @@
                     </tabs>
                   </TabPane>
                </children>
-            </Pane>
+            </VBox>
          </children>
          <padding>
             <Insets bottom="10.0" left="10.0" right="10.0" />

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -3,15 +3,17 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Cursor?>
 <?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
 <?import javafx.scene.effect.DropShadow?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
-<?import javafx.scene.paint.Color?>
 <?import javafx.scene.shape.Line?>
 <?import javafx.scene.text.Font?>
 
@@ -242,93 +244,24 @@
                   </Button>
                </children>
             </StackPane>
-            <Label text=" Welcome back, Admin!" textFill="#f5f5f5">
-               <font>
-                  <Font name="Bookman Old Style" size="24.0" />
-               </font>
-            </Label>
-            <Label text="Monitor inventory levels and company performance at a glance" textFill="#e1e1e1">
-               <VBox.margin>
-                  <Insets left="10.0" />
-               </VBox.margin></Label>
-            <Label text="   DATE" textFill="#a6a6a6">
-               <font>
-                  <Font size="14.0" />
-               </font>
-            </Label>
-      
-                  <!-- Graphs (Horizontal Box) -->
-            <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="60.0" prefWidth="709.0" spacing="20.0" VBox.vgrow="ALWAYS">
+            <Pane>
                <children>
-                  <StackPane maxHeight="130.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="80.0" prefWidth="130.0" style="-fx-background-color: #0B1739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
-                     <effect>
-                        <DropShadow blurType="ONE_PASS_BOX" offsetX="3.0" offsetY="3.0">
-                           <color>
-                              <Color opacity="0.5" />
-                           </color>
-                        </DropShadow>
-                     </effect>
-                     <HBox.margin>
-                        <Insets bottom="20.0" left="10.0" right="10.0" top="10.0" />
-                     </HBox.margin>
-                  </StackPane>
-                  <StackPane maxHeight="130.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="80.0" prefWidth="130.0" style="-fx-background-color: #0B1739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
-                     <effect>
-                        <DropShadow blurType="ONE_PASS_BOX" offsetX="3.0" offsetY="3.0">
-                           <color>
-                              <Color opacity="0.5" />
-                           </color>
-                        </DropShadow>
-                     </effect>
-                     <HBox.margin>
-                        <Insets bottom="30.0" left="10.0" right="10.0" top="10.0" />
-                     </HBox.margin>
-                  </StackPane>
+                  <TabPane nodeOrientation="LEFT_TO_RIGHT" tabClosingPolicy="UNAVAILABLE">
+                    <tabs>
+                      <Tab text="Untitled Tab 1">
+                        <content>
+                          <AnchorPane prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: #081028;" />
+                        </content>
+                      </Tab>
+                      <Tab text="Untitled Tab 2">
+                        <content>
+                          <AnchorPane prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #081028k;" />
+                        </content>
+                      </Tab>
+                    </tabs>
+                  </TabPane>
                </children>
-               <padding>
-                  <Insets left="10.0" right="20.0" top="10.0" />
-               </padding>
-               <VBox.margin>
-                  <Insets left="10.0" />
-               </VBox.margin>
-            </HBox>
-            <HBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" prefHeight="366.0" prefWidth="605.0" VBox.vgrow="ALWAYS">
-               <VBox.margin>
-                  <Insets bottom="10.0" left="10.0" right="15.0" />
-               </VBox.margin>
-               <children>
-                  <!-- Left Side (Graphs) -->
-                  <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="221.0" prefWidth="554.0" style="-fx-background-radius: 15 0 0 0;" HBox.hgrow="ALWAYS">
-                     <children>
-                        <VBox maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="42.0" prefWidth="682.0" style="-fx-background-color: #0B1739; -fx-background-radius: 15 15 0 0; -fx-border-radius: 15 0 0 0; -fx-border-color: transparent transparent rgba(255,255,255,0.1) transparent;" VBox.vgrow="ALWAYS">
-                           <cursor>
-                              <Cursor fx:constant="DEFAULT" />
-                           </cursor>
-                           <VBox.margin>
-                              <Insets />
-                           </VBox.margin>
-                        </VBox>
-                        <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="134.0" prefWidth="330.0" style="-fx-background-radius: 0 0 15 15; -fx-background-color: #0B1739;" VBox.vgrow="ALWAYS">
-                           <cursor>
-                              <Cursor fx:constant="DEFAULT" />
-                           </cursor>
-                           <VBox.margin>
-                              <Insets />
-                           </VBox.margin>
-                        </VBox>
-                     </children>
-                     <padding>
-                        <Insets left="10.0" />
-                     </padding>
-                     <cursor>
-                        <Cursor fx:constant="NONE" />
-                     </cursor>
-                     <HBox.margin>
-                        <Insets bottom="10.0" />
-                     </HBox.margin>
-                  </VBox>
-               </children>
-            </HBox>
+            </Pane>
          </children>
          <padding>
             <Insets bottom="10.0" left="10.0" right="10.0" />


### PR DESCRIPTION


## 🧐 Because  
the right side of the system should be a tab pane to interact with side panel buttons

## 🛠 This PR  

- Added tab pane which is fully responsive to both system sizes,min and max
- Color is intentionally pink to see the functionality and responsiveness of the tab pane


## 🔗 Issue  


## 📚 Documentation  
![Screenshot 2025-05-19 191956](https://github.com/user-attachments/assets/98e35d81-ed6b-4991-9fb7-4b878026cfbb)
![Screenshot 2025-05-19 191947](https://github.com/user-attachments/assets/7e4da262-b5f4-4f73-98b2-ab33dfdb3869)



## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  

