### PR TITLE
Fixed tab button headers name with respect to side bar buttons name

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -48,7 +48,10 @@ public class dashboardController {
 
 
 
+
     }
+
+
 
     @FXML
     private void handleMinimize() {
@@ -99,6 +102,12 @@ public class dashboardController {
             });
         });
     }
+
+
+
+
+
+
 
 
 

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -247,32 +247,32 @@
                <children>
                   <TabPane fx:id="tabpane" nodeOrientation="LEFT_TO_RIGHT" prefHeight="1000.0" tabClosingPolicy="UNAVAILABLE">
                     <tabs>
-                      <Tab text="dashboard">
+                      <Tab text="Dashboard">
                         <content>
                           <AnchorPane fx:id="dashboardpane" prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: #081028; -fx-border-color: white;" />
                         </content>
                       </Tab>
-                      <Tab text="manage inventory">
+                      <Tab text="Manage Inventory">
                         <content>
                           <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #081028k;" />
                         </content>
                       </Tab>
-                        <Tab text="sales">
+                        <Tab text="Sales">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
                           </content>
                         </Tab>
-                        <Tab text="forecasting">
+                        <Tab text="Forecasting">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
                           </content>
                         </Tab>
-                        <Tab text="settings">
+                        <Tab text="Settings">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
                           </content>
                         </Tab>
-                        <Tab text="help and support">
+                        <Tab text="Help and Support">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
                           </content>

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -38,7 +38,7 @@
                         <Image url="@../images/dashboard_gray.png" />
                      </image>
                   </ImageView>
-                  <Button fx:id="dashboardbutton" alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="150.0" style="-fx-background-color: transparent;" text="Dashboard" textFill="#aeb9e1">
+                  <Button alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="150.0" style="-fx-background-color: transparent;" text="Dashboard" textFill="#aeb9e1">
                      <HBox.margin>
                         <Insets left="8.0" top="-2.0" />
                      </HBox.margin>
@@ -58,7 +58,7 @@
                         <Image url="@../images/inventory_gray.png" />
                      </image>
                   </ImageView>
-                  <Button fx:id="inventorybutton" alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="153.0" style="-fx-background-color: transparent;" text="Manage Inventory" textFill="#aeb9e1">
+                  <Button alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="153.0" style="-fx-background-color: transparent;" text="Manage Inventory" textFill="#aeb9e1">
                      <HBox.margin>
                         <Insets left="9.0" top="-7.0" />
                      </HBox.margin>
@@ -245,38 +245,18 @@
             </StackPane>
             <VBox>
                <children>
-                  <TabPane fx:id="tabpane" nodeOrientation="LEFT_TO_RIGHT" prefHeight="1000.0" tabClosingPolicy="UNAVAILABLE">
+                  <TabPane fx:id="tabpane" nodeOrientation="LEFT_TO_RIGHT" prefHeight="1000.0" style="-fx-background-color: #081028;" tabClosingPolicy="UNAVAILABLE">
                     <tabs>
-                      <Tab text="Dashboard">
+                      <Tab text="Untitled Tab 1">
                         <content>
-                          <AnchorPane fx:id="dashboardpane" prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: #081028; -fx-border-color: white;" />
+                          <AnchorPane prefHeight="738.0" prefWidth="717.0" style="-fx-background-color: pink;" />
                         </content>
                       </Tab>
-                      <Tab text="Manage Inventory">
+                      <Tab text="Untitled Tab 2">
                         <content>
-                          <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #081028k;" />
+                          <AnchorPane prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: maroon;" />
                         </content>
                       </Tab>
-                        <Tab text="Sales">
-                          <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
-                          </content>
-                        </Tab>
-                        <Tab text="Forecasting">
-                          <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
-                          </content>
-                        </Tab>
-                        <Tab text="Settings">
-                          <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
-                          </content>
-                        </Tab>
-                        <Tab text="Help and Support">
-                          <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
-                          </content>
-                        </Tab>
                     </tabs>
                   </TabPane>
                </children>

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -247,16 +247,36 @@
                <children>
                   <TabPane fx:id="tabpane" nodeOrientation="LEFT_TO_RIGHT" prefHeight="1000.0" tabClosingPolicy="UNAVAILABLE">
                     <tabs>
-                      <Tab text="Untitled Tab 1">
+                      <Tab text="dashboard">
                         <content>
-                          <AnchorPane fx:id="dashboardpane" prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: pink;" />
+                          <AnchorPane fx:id="dashboardpane" prefHeight="571.0" prefWidth="721.0" style="-fx-background-color: #081028; -fx-border-color: white;" />
                         </content>
                       </Tab>
-                      <Tab text="Untitled Tab 2">
+                      <Tab text="manage inventory">
                         <content>
                           <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #081028k;" />
                         </content>
                       </Tab>
+                        <Tab text="sales">
+                          <content>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                          </content>
+                        </Tab>
+                        <Tab text="forecasting">
+                          <content>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                          </content>
+                        </Tab>
+                        <Tab text="settings">
+                          <content>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                          </content>
+                        </Tab>
+                        <Tab text="help and support">
+                          <content>
+                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" />
+                          </content>
+                        </Tab>
                     </tabs>
                   </TabPane>
                </children>


### PR DESCRIPTION


## 🧐 Because  
It is easier to develop when the names are accordingly



## 🔗 Issue  

Closes #62   

## 📚 Documentation  
![Screenshot 2025-05-21 120300](https://github.com/user-attachments/assets/7b6fe3ae-c8dc-4143-9a24-e659c59bba3a)

---

## ✅ Pull Request Requirements  

- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
