### PR TITLE
Clicking 'manage inventory' on sidebar should move the screen to an e…

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -23,6 +23,8 @@ public class dashboardController {
     @FXML private TabPane tabpane;
     @FXML private Button dashboardbutton;
     @FXML private AnchorPane dashboardpane;
+    @FXML private Button inventorybutton;
+    @FXML private AnchorPane inventorypane;
 
 
     private double xOffset = 0;
@@ -54,6 +56,7 @@ public class dashboardController {
 
 
         TabSwitch(dashboardbutton, dashboardpane);
+        TabSwitch(inventorybutton, inventorypane);
 
 
 

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -38,7 +38,7 @@
                         <Image url="@../images/dashboard_gray.png" />
                      </image>
                   </ImageView>
-                  <Button alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="150.0" style="-fx-background-color: transparent;" text="Dashboard" textFill="#aeb9e1">
+                  <Button fx:id="dashboardbutton" alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="150.0" style="-fx-background-color: transparent;" text="Dashboard" textFill="#aeb9e1">
                      <HBox.margin>
                         <Insets left="8.0" top="-2.0" />
                      </HBox.margin>
@@ -58,7 +58,7 @@
                         <Image url="@../images/inventory_gray.png" />
                      </image>
                   </ImageView>
-                  <Button alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="153.0" style="-fx-background-color: transparent;" text="Manage Inventory" textFill="#aeb9e1">
+                  <Button fx:id="inventorybutton" alignment="TOP_LEFT" mnemonicParsing="false" prefHeight="30.0" prefWidth="153.0" style="-fx-background-color: transparent;" text="Manage Inventory" textFill="#aeb9e1">
                      <HBox.margin>
                         <Insets left="9.0" top="-7.0" />
                      </HBox.margin>
@@ -249,7 +249,7 @@
                     <tabs>
                       <Tab text="Dashboard">
                         <content>
-                          <AnchorPane prefHeight="738.0" prefWidth="717.0" style="-fx-background-color: pink;" />
+                          <AnchorPane fx:id="dashboardpane" prefHeight="738.0" prefWidth="717.0" style="-fx-background-color: pink;" />
                         </content>
                       </Tab>
                       <Tab text="Manage Inventory">
@@ -262,17 +262,17 @@
                             <AnchorPane fx:id="salespane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #022058;" />
                           </content>
                         </Tab>
-                        <Tab fx:id="forecastingbutton" text="Forecasting">
+                        <Tab text="Forecasting">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: brown;" />
                           </content>
                         </Tab>
-                        <Tab fx:id="settingsbutton" text="Settings">
+                        <Tab text="Settings">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: teal;" />
                           </content>
                         </Tab>
-                        <Tab fx:id="helpbutton" text="Help and Support">
+                        <Tab text="Help and Support">
                           <content>
                             <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: beige;" />
                           </content>


### PR DESCRIPTION


## 🧐 Because  
manage inventory button does not have functionality yet

## 🛠 This PR  
when manage inventory is clicked it will show specific panel for this button

## 🔗 Issue  
Closes #34  

## 📚 Documentation  
![image](https://github.com/user-attachments/assets/d02eb32b-8ce5-45ff-afb3-d1dd46433d13)



## ✅ Pull Request Requirements  

- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
