### PR TITLE
Clicking 'sales' on sidebar should move the screen to an empty panel

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -25,6 +25,8 @@ public class dashboardController {
     @FXML private AnchorPane dashboardpane;
     @FXML private Button inventorybutton;
     @FXML private AnchorPane inventorypane;
+    @FXML private Button salesbutton;
+    @FXML private AnchorPane salespane;
 
 
     private double xOffset = 0;
@@ -57,6 +59,7 @@ public class dashboardController {
 
         TabSwitch(dashboardbutton, dashboardpane);
         TabSwitch(inventorybutton, inventorypane);
+        TabSwitch(salesbutton, salespane);
 
 
 


### PR DESCRIPTION

## 🧐 Because  
sales button does not have a function yet 

## 🛠 This PR  
when sales button is clicked it will show its own pane

## 🔗 Issue  
Closes #46 

## 📚 Documentation  
![image](https://github.com/user-attachments/assets/bc9d5546-22da-4739-a053-9524dd9c432c)


## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
