### PR TITLE
Clicking 'forecasting' on sidebar should move the screen to an empty …

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -25,6 +25,8 @@ public class dashboardController {
     @FXML private AnchorPane dashboardpane;
     @FXML private Button inventorybutton;
     @FXML private AnchorPane inventorypane;
+    @FXML private Button forecastingbutton;
+    @FXML private AnchorPane forecastingpane;
 
 
     private double xOffset = 0;
@@ -57,6 +59,7 @@ public class dashboardController {
 
         TabSwitch(dashboardbutton, dashboardpane);
         TabSwitch(inventorybutton, inventorypane);
+        TabSwitch(forecastingbutton, forecastingpane);
 
 
 

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -264,7 +264,7 @@
                         </Tab>
                         <Tab text="Forecasting">
                           <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: brown;" />
+                            <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: brown;" />
                           </content>
                         </Tab>
                         <Tab text="Settings">


### PR DESCRIPTION

## 🧐 Because  
button forecasting does not have function yet

## 🛠 This PR  
when button forecasting is clicked it will show its pane

## 🔗 Issue  
Closes #47 


## 📚 Documentation  
![image](https://github.com/user-attachments/assets/2a92d607-258c-47cc-aa8d-e7f815c06888)


## ✅ Pull Request Requirements  

- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
