### PR TITLE
Clicking 'settings' on sidebar should move the screen to an empty panel

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -29,6 +29,8 @@ public class dashboardController {
     @FXML private AnchorPane forecastingpane;
     @FXML private Button salesbutton;
     @FXML private AnchorPane salespane;
+    @FXML private Button settingsbutton;
+    @FXML private AnchorPane settingspane;
 
 
     private double xOffset = 0;
@@ -63,6 +65,7 @@ public class dashboardController {
         TabSwitch(inventorybutton, inventorypane);
         TabSwitch(forecastingbutton, forecastingpane);
         TabSwitch(salesbutton, salespane);
+        TabSwitch(settingsbutton, settingspane);
 
 
 

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -269,7 +269,7 @@
                         </Tab>
                         <Tab text="Settings">
                           <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: teal;" />
+                            <AnchorPane fx:id="settingspane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: teal;" />
                           </content>
                         </Tab>
                         <Tab text="Help and Support">


### PR DESCRIPTION


## 🧐 Because   
button sales does not have function


## 🛠 This PR  
when button sales is clicked it will show its pane



## 🔗 Issue  
Closes #48  

## 📚 Documentation  
![image](https://github.com/user-attachments/assets/3d552c3e-2fbe-4c5f-8add-09f8181a2503)


## ✅ Pull Request Requirements  

- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
