### PR TITLE
Clicking 'help and support' on sidebar should move the screen to an e…

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -31,6 +31,8 @@ public class dashboardController {
     @FXML private AnchorPane salespane;
     @FXML private Button settingsbutton;
     @FXML private AnchorPane settingspane;
+    @FXML private Button helpbutton;
+    @FXML private AnchorPane helppane;
 
 
     private double xOffset = 0;
@@ -66,6 +68,7 @@ public class dashboardController {
         TabSwitch(forecastingbutton, forecastingpane);
         TabSwitch(salesbutton, salespane);
         TabSwitch(settingsbutton, settingspane);
+        TabSwitch(helpbutton, helppane);
 
 
 

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -274,7 +274,7 @@
                         </Tab>
                         <Tab text="Help and Support">
                           <content>
-                            <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: beige;" />
+                            <AnchorPane fx:id="helppane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: beige;" />
                           </content>
                         </Tab>
                     </tabs>


### PR DESCRIPTION


## 🧐 Because  
button help and sypport does not have function yet


## 🛠 This PR  
when button help and support is clicked it will show its pane



## 🔗 Issue  

Closes #49    


## 📚 Documentation  
![image](https://github.com/user-attachments/assets/c56dcd12-2f4d-4784-b3bb-c774cf7e2f17)




## ✅ Pull Request Requirements  

- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  