### PR TITLE
73 UI refactor   fix side bar buttons width and remove drop down arrow of settings and help and support

### DIFF
--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -147,14 +147,6 @@
                         <Font size="16.0" />
                      </font>
                   </Button>
-                  <ImageView fitHeight="14.0" fitWidth="22.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@../images/arrow_right_gray.png" />
-                     </image>
-                     <HBox.margin>
-                        <Insets top="10.0" />
-                     </HBox.margin>
-                  </ImageView>
                </children>
                <VBox.margin>
                   <Insets left="30.0" right="15.0" top="20.0" />
@@ -178,17 +170,9 @@
                         <Insets left="10.0" />
                      </HBox.margin>
                   </Button>
-                  <ImageView fitHeight="14.0" fitWidth="22.0" pickOnBounds="true" preserveRatio="true">
-                     <image>
-                        <Image url="@../images/arrow_right_gray.png" />
-                     </image>
-                     <HBox.margin>
-                        <Insets top="10.0" />
-                     </HBox.margin>
-                  </ImageView>
                </children>
                <VBox.margin>
-                  <Insets bottom="30.0" left="30.0" right="15.0" top="15.0" />
+                  <Insets bottom="33.0" left="30.0" right="15.0" top="15.0" />
                </VBox.margin>
             </HBox>
          </children>

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -188,7 +188,7 @@
                   </ImageView>
                </children>
                <VBox.margin>
-                  <Insets left="30.0" right="15.0" top="15.0" />
+                  <Insets bottom="30.0" left="30.0" right="15.0" top="15.0" />
                </VBox.margin>
             </HBox>
          </children>


### PR DESCRIPTION


## 🧐 Because  
the button bars was too down and not UI friendly

## 🛠 This PR  
- added margin do the hbox to move these down buttons upward

## 🔗 Issue  

Closes #71 


## 📚 Documentation  
![image](https://github.com/user-attachments/assets/7a966be1-4922-4640-bc27-cab6fb127ab9)
![image](https://github.com/user-attachments/assets/294b2589-cef7-4342-bdf6-b48a9306c48b)


## ✅ Pull Request Requirements  

- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  