### PR TITLE
[Bug] [UI] - sidebar button navigation malfunction specifically "dashboard"

### DIFF
--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -21,7 +21,7 @@
 
    <!-- Left Panel (Sidebar) -->
    <left>
-      <VBox prefHeight="641.0" prefWidth="263.0" style="-fx-background-color: #081028;" BorderPane.alignment="CENTER">
+      <VBox minWidth="263.0" style="-fx-background-color: #081028;" BorderPane.alignment="CENTER">
          <effect>
             <DropShadow blurType="GAUSSIAN" height="1.0" radius="0.0" width="0.0" />
          </effect>
@@ -127,7 +127,8 @@
             <HBox prefHeight="166.0" prefWidth="263.0" VBox.vgrow="ALWAYS">
                <VBox.margin>
                   <Insets />
-               </VBox.margin></HBox>
+               </VBox.margin>
+            </HBox>
             <Line endX="150.0" startX="-100.0" stroke="#4c5574">
                <VBox.margin>
                   <Insets top="60.0" />
@@ -188,12 +189,11 @@
 
    <!-- Main Content Area -->
    <center>
-      <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="644.0" prefWidth="709.0" style="-fx-background-color: #081028; -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 45.1, 0.75, 0, 4);;" BorderPane.alignment="CENTER">
+      <VBox minHeight="-Infinity" minWidth="-Infinity" style="-fx-background-color: #081028; -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 45.1, 0.75, 0, 4);;" BorderPane.alignment="CENTER" VBox.vgrow="ALWAYS">
          <children>
-            <StackPane alignment="CENTER_RIGHT" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0" prefWidth="719.0">
+            <StackPane alignment="CENTER_RIGHT" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0">
                <children>
-      
-                                                <Button fx:id="exitButton" alignment="TOP_RIGHT" mnemonicParsing="false" onAction="#handleExit" prefHeight="29.0" prefWidth="20.0" style="-fx-background-color: transparent;" textOverrun="CLIP" translateZ="3.0" wrapText="true">
+                  <Button fx:id="exitButton" alignment="TOP_RIGHT" mnemonicParsing="false" onAction="#handleExit" prefHeight="29.0" prefWidth="20.0" style="-fx-background-color: transparent;" textOverrun="CLIP" translateZ="3.0" wrapText="true">
                      <cursor>
                         <Cursor fx:constant="HAND" />
                      </cursor>
@@ -234,122 +234,125 @@
                   </Button>
                </children>
             </StackPane>
-            <VBox>
+            <VBox VBox.vgrow="ALWAYS">
                <children>
-                  <TabPane fx:id="tabpane" nodeOrientation="LEFT_TO_RIGHT" prefHeight="1000.0" style="-fx-background-color: #081028;" tabClosingPolicy="UNAVAILABLE">
-                    <tabs>
-                      <Tab text="Dashboard">
-                         <content>
-                            <StackPane prefHeight="150.0" prefWidth="200.0">
-                               <children>
-                                  <Label text="Welcome back, Admin" textFill="WHITE" StackPane.alignment="TOP_LEFT">
-                                     <font>
-                                        <Font name="Baskerville Old Face" size="24.0" />
-                                     </font>
-                                     <StackPane.margin>
-                                        <Insets left="20.0" />
-                                     </StackPane.margin>
-                                  </Label>
-                                  <Label layoutX="354.0" layoutY="287.0" text="Monitor inventory levels and company performance at a glance" textFill="WHITE" StackPane.alignment="TOP_LEFT">
-                                     <StackPane.margin>
-                                        <Insets left="20.0" top="27.0" />
-                                     </StackPane.margin>
-                                     <font>
-                                        <Font size="10.0" />
-                                     </font>
-                                  </Label>
-                                  <Label layoutX="354.0" layoutY="287.0" text="DATE:" textFill="WHITE" StackPane.alignment="TOP_LEFT">
-                                     <StackPane.margin>
-                                        <Insets left="20.0" top="55.0" />
-                                     </StackPane.margin>
-                                     <font>
-                                        <Font size="16.0" />
-                                     </font>
-                                  </Label>
-                                  <HBox prefHeight="100.0" prefWidth="200.0">
-                                     <children>
-                                        <StackPane maxHeight="130.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="80.0" prefWidth="130.0" style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
-                                           <HBox.margin>
-                                              <Insets bottom="20.0" left="20.0" right="20.0" top="90.0" />
-                                           </HBox.margin>
-                                           <effect>
-                                              <DropShadow />
-                                           </effect>
-                                        </StackPane>
-                                        <StackPane layoutX="10.0" layoutY="10.0" maxHeight="130.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="80.0" prefWidth="130.0" style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
-                                           <effect>
-                                              <DropShadow />
-                                           </effect>
-                                           <HBox.margin>
-                                              <Insets bottom="20.0" left="10.0" right="20.0" top="90.0" />
-                                           </HBox.margin>
-                                        </StackPane>
-                                     </children>
-                                  </HBox>
-                                  <HBox layoutX="10.0" layoutY="10.0" prefHeight="100.0" prefWidth="200.0">
-                                     <children>
-                                        <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="274.0" prefWidth="690.0" style="-fx-background-radius: 15 0 0 0;" HBox.hgrow="ALWAYS">
-                                           <HBox.margin>
-                                              <Insets top="240.0" />
-                                           </HBox.margin>
-                                           <children>
-                                              <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="150.0" prefWidth="677.0" style="-fx-background-color: #081739; -fx-background-radius: 15 15 0 0;" VBox.vgrow="ALWAYS">
-                                                 <VBox.margin>
-                                                    <Insets left="10.0" right="25.0" />
-                                                 </VBox.margin>
-                                                 <effect>
-                                                    <DropShadow radius="10.0" offsetX="0.0" offsetY="-4.0" spread="0.5" color="#00000040"/>
-                                                 </effect>
-                                              </VBox>
-
-                                              <VBox layoutX="20.0" layoutY="10.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="172.0" prefWidth="677.0" style="-fx-background-color: #081739; -fx-background-radius: 0 0 15 15;" VBox.vgrow="ALWAYS">
-                                                 <VBox.margin>
-                                                    <Insets bottom="20.0" left="10.0" right="25.0" />
-                                                 </VBox.margin>
-                                                 <effect>
-                                                    <DropShadow radius="10.0" offsetX="0.0" offsetY="4.0" spread="0.5" color="#00000040"/>
-                                                 </effect>
-                                                 <padding>
-                                                    <Insets bottom="10.0" />
-                                                 </padding>
-                                              </VBox>
-                                           </children>
-                                           <padding>
-                                              <Insets left="10.0" />
-                                           </padding>
-                                        </VBox>
-                                     </children>
-                                  </HBox>
-                               </children>
-                            </StackPane>
-                         </content>
-                      </Tab>
-                      <Tab text="Manage Inventory">
-                        <content>
-                          <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #581028;" />
-                        </content>
-                      </Tab>
+                  <TabPane fx:id="tabpane" nodeOrientation="LEFT_TO_RIGHT" style="-fx-background-color: #081028;" tabClosingPolicy="UNAVAILABLE" VBox.vgrow="ALWAYS">
+                     <tabs>
+                        <Tab text="Dashboard">
+                           <content>
+                              <AnchorPane fx:id="dashboardpane" prefHeight="588.0" prefWidth="726.0">
+                                 <children>
+                                    <StackPane AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                                       <children>
+                                          <Label text="Welcome back, Admin" textFill="WHITE" StackPane.alignment="TOP_LEFT">
+                                             <font>
+                                                <Font name="Baskerville Old Face" size="24.0" />
+                                             </font>
+                                             <StackPane.margin>
+                                                <Insets left="20.0" />
+                                             </StackPane.margin>
+                                          </Label>
+                                          <Label layoutX="354.0" layoutY="287.0" text="Monitor inventory levels and company performance at a glance" textFill="WHITE" StackPane.alignment="TOP_LEFT">
+                                             <StackPane.margin>
+                                                <Insets left="20.0" top="27.0" />
+                                             </StackPane.margin>
+                                             <font>
+                                                <Font size="10.0" />
+                                             </font>
+                                          </Label>
+                                          <Label layoutX="354.0" layoutY="287.0" text="DATE:" textFill="WHITE" StackPane.alignment="TOP_LEFT">
+                                             <StackPane.margin>
+                                                <Insets left="20.0" top="55.0" />
+                                             </StackPane.margin>
+                                             <font>
+                                                <Font size="16.0" />
+                                             </font>
+                                          </Label>
+                                          <HBox prefHeight="100.0" prefWidth="200.0">
+                                             <children>
+                                                <StackPane maxHeight="130.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="80.0" prefWidth="130.0" style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
+                                                   <HBox.margin>
+                                                      <Insets bottom="20.0" left="20.0" right="20.0" top="90.0" />
+                                                   </HBox.margin>
+                                                   <effect>
+                                                      <DropShadow />
+                                                   </effect>
+                                                </StackPane>
+                                                <StackPane layoutX="10.0" layoutY="10.0" maxHeight="130.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="80.0" prefWidth="130.0" style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
+                                                   <effect>
+                                                      <DropShadow />
+                                                   </effect>
+                                                   <HBox.margin>
+                                                      <Insets bottom="20.0" left="10.0" right="20.0" top="90.0" />
+                                                   </HBox.margin>
+                                                </StackPane>
+                                             </children>
+                                          </HBox>
+                                          <HBox layoutX="10.0" layoutY="10.0" prefHeight="100.0" prefWidth="200.0">
+                                             <children>
+                                                <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="274.0" prefWidth="690.0" style="-fx-background-radius: 15 0 0 0;" HBox.hgrow="ALWAYS">
+                                                   <HBox.margin>
+                                                      <Insets top="240.0" />
+                                                   </HBox.margin>
+                                                   <children>
+                                                      <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="150.0" prefWidth="677.0" style="-fx-background-color: #081739; -fx-background-radius: 15 15 0 0;" VBox.vgrow="ALWAYS">
+                                                         <VBox.margin>
+                                                            <Insets left="10.0" right="20.0" />
+                                                         </VBox.margin>
+                                                         <effect>
+                                                            <DropShadow color="#00000040" offsetX="0.0" offsetY="-4.0" radius="10.0" spread="0.5" />
+                                                         </effect>
+                                                      </VBox>
+                                                      <VBox layoutX="20.0" layoutY="10.0" minHeight="-Infinity" minWidth="-Infinity" prefHeight="172.0" prefWidth="677.0" style="-fx-background-color: #081739; -fx-background-radius: 0 0 15 15;" VBox.vgrow="ALWAYS">
+                                                         <VBox.margin>
+                                                            <Insets bottom="20.0" left="10.0" right="20.0" />
+                                                         </VBox.margin>
+                                                         <effect>
+                                                            <DropShadow color="#00000040" offsetX="0.0" offsetY="4.0" radius="10.0" spread="0.5" />
+                                                         </effect>
+                                                         <padding>
+                                                            <Insets bottom="10.0" />
+                                                         </padding>
+                                                      </VBox>
+                                                   </children>
+                                                   <padding>
+                                                      <Insets left="10.0" />
+                                                   </padding>
+                                                </VBox>
+                                             </children>
+                                          </HBox>
+                                       </children>
+                                    </StackPane>
+                                 </children>
+                              </AnchorPane>
+                           </content>
+                        </Tab>
+                        <Tab text="Manage Inventory">
+                           <content>
+                              <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #581028;" />
+                           </content>
+                        </Tab>
                         <Tab text="Sales">
-                          <content>
-                            <AnchorPane fx:id="salespane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #022058;" />
-                          </content>
+                           <content>
+                              <AnchorPane fx:id="salespane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #022058;" />
+                           </content>
                         </Tab>
                         <Tab text="Forecasting">
-                          <content>
-                            <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: brown;" />
-                          </content>
+                           <content>
+                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: brown;" />
+                           </content>
                         </Tab>
                         <Tab text="Settings">
-                          <content>
-                            <AnchorPane fx:id="settingspane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: teal;" />
-                          </content>
+                           <content>
+                              <AnchorPane fx:id="settingspane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: teal;" />
+                           </content>
                         </Tab>
                         <Tab text="Help and Support">
-                          <content>
-                            <AnchorPane fx:id="helppane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: beige;" />
-                          </content>
+                           <content>
+                              <AnchorPane fx:id="helppane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: beige;" />
+                           </content>
                         </Tab>
-                    </tabs>
+                     </tabs>
                   </TabPane>
                </children>
             </VBox>


### PR DESCRIPTION

## 🧐 Because  
Clicking the other buttons from dashboard button and then going back will show the previous button's panel instead of the dashboard

## 🛠 This PR  
-Navigation now goes back to the button's specific tab

## 🔗 Issue  
Closes #81 



## 📚 Documentation  
![image](https://github.com/user-attachments/assets/c168353f-3e32-406a-92fa-af4e19301a56)
![image](https://github.com/user-attachments/assets/123597a4-6619-4440-8b39-cee5f9530788)
![image](https://github.com/user-attachments/assets/b1acb86d-27b3-4357-85df-9219a93e678a)


## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
