### PR TITLE
[Feat] [UI] - add background color on "manage inventory" panel

### DIFF
--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -189,7 +189,7 @@
 
    <!-- Main Content Area -->
    <center>
-      <VBox minHeight="-Infinity" minWidth="-Infinity" style="-fx-background-color: #081028; -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 45.1, 0.75, 0, 4);;" BorderPane.alignment="CENTER" VBox.vgrow="ALWAYS">
+      <VBox minHeight="-Infinity" minWidth="-Infinity" prefHeight="652.0" prefWidth="747.0" style="-fx-background-color: #081028; -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 45.1, 0.75, 0, 4);;" BorderPane.alignment="CENTER" VBox.vgrow="ALWAYS">
          <children>
             <StackPane alignment="CENTER_RIGHT" minHeight="-Infinity" minWidth="-Infinity" prefHeight="40.0">
                <children>
@@ -329,7 +329,7 @@
                         </Tab>
                         <Tab text="Manage Inventory">
                            <content>
-                              <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #581028;" />
+                              <AnchorPane fx:id="inventorypane" prefHeight="588.0" prefWidth="726.0" style="-fx-background-color: #081028;" />
                            </content>
                         </Tab>
                         <Tab text="Sales">


### PR DESCRIPTION
## 🧐 Because  
As of now, the current panel for manage inventory is empty and that the color is a placeholder. Added a background color that matches the figma design.

## 🛠 This PR  
-Added a background color that matches the figma design

## 🔗 Issue  
<!-- Link the issue this PR addresses. Example:  
Closes #85  

## 📚 Documentation  
![image](https://github.com/user-attachments/assets/214e5e66-8753-4a2c-8671-b46b96c495c9)

## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
