### PR TITLE
[Enhance] [UI] - add background color on forecasting panel

### DIFF
--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -402,7 +402,7 @@
                         </Tab>
                         <Tab text="Forecasting">
                            <content>
-                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: brown;" />
+                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;" />
                            </content>
                         </Tab>
                         <Tab text="Settings">


### PR DESCRIPTION
## 🧐 Because  
The forecasting panel does not have the right background color. Changed it to match the figma reference design

> Input:

## 🛠 This PR  
-Changed the background in Forecasting panel

## 🔗 Issue  
Closes #94 



## 📚 Documentation  
![image](https://github.com/user-attachments/assets/f22bd0c3-f7ef-45f9-89f6-5ce6bd83d331)
![image](https://github.com/user-attachments/assets/71699f33-cf4d-41c0-8219-85ea70a1a460)


## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
