### PR TITLE
[Enhance] [UI] - add date on both sales and forecasting panel based on figma reference design

### DIFF
--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -391,6 +391,14 @@
                            <content>
                               <AnchorPane fx:id="salespane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;">
                                  <children>
+                                    <Label text="DATE:" textFill="WHITE">
+                                       <font>
+                                          <Font name="Arial" size="16.0" />
+                                       </font>
+                                       <padding>
+                                          <Insets left="27.0" top="25.0" />
+                                       </padding>
+                                    </Label>
                                     <VBox fx:id="contentVBox" layoutX="26.4" layoutY="69.0" prefHeight="487.0" prefWidth="671.0" style="-fx-background-color: #081739; -fx-background-radius: 15;" AnchorPane.bottomAnchor="18.0" AnchorPane.leftAnchor="26.0" AnchorPane.rightAnchor="29.0" AnchorPane.topAnchor="69.0">
                                        <effect>
                                           <DropShadow />
@@ -402,7 +410,17 @@
                         </Tab>
                         <Tab text="Forecasting">
                            <content>
-                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;" />
+                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;">
+                                 <children>
+                                    <Label text="DATE:" textFill="WHITE">
+                                       <font>
+                                          <Font name="Arial" size="16.0" />
+                                       </font>
+                                       <padding>
+                                          <Insets left="27.0" top="25.0" />
+                                       </padding>
+                                    </Label>
+                                 </children></AnchorPane>
                            </content>
                         </Tab>
                         <Tab text="Settings">


### PR DESCRIPTION

## 🧐 Because  
The current sales and forecasting panels did not have any dates. Dates have been added to match the Figma reference design.

## 🛠 This PR  
-Added dates in the following panels:
**Sales**
**Forecasting**

## 🔗 Issue  
Closes #95 


## 📚 Documentation  
![image](https://github.com/user-attachments/assets/db2afe38-90f0-4802-8b5e-1694daa9da00)
![image](https://github.com/user-attachments/assets/a27fe19e-3546-4e5d-9963-878f46731fa8)


## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
