### PR TITLE
[Feature] [UI] - add background color on Contact us to match reference design

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Database configuration
-DB_PORT=3307
+DB_PORT=3306
 DB_PASSWORD=computerengineering
 
 # PHPMyAdmin configuration

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -426,12 +426,10 @@
                         </Tab>
                         <Tab text="Forecasting">
                            <content>
-                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0"
-                                          prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;">
+                              <AnchorPane fx:id="forecastingpane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;">
                                  <children>
                                     <!-- Main container VBox -->
-                                    <VBox spacing="20" AnchorPane.topAnchor="15.0" AnchorPane.bottomAnchor="15.0"
-                                          AnchorPane.leftAnchor="27.0" AnchorPane.rightAnchor="28.0">
+                                    <VBox spacing="20" AnchorPane.bottomAnchor="15.0" AnchorPane.leftAnchor="27.0" AnchorPane.rightAnchor="28.0" AnchorPane.topAnchor="15.0">
 
                                        <!-- DATE label -->
                                        <Label text="DATE:" textFill="WHITE">
@@ -444,8 +442,7 @@
                                        </Label>
 
                                        <!-- Main content box -->
-                                       <VBox fx:id="forecastingContentVBox" style="-fx-background-color: #081739; -fx-background-radius: 15;"
-                                             VBox.vgrow="ALWAYS">
+                                       <VBox fx:id="forecastingContentVBox" style="-fx-background-color: #081739; -fx-background-radius: 15;" VBox.vgrow="ALWAYS">
                                           <effect>
                                              <DropShadow />
                                           </effect>
@@ -453,12 +450,12 @@
 
                                        <!-- Two bottom boxes side by side -->
                                        <HBox spacing="20">
-                                          <HBox style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS" minHeight="100">
+                                          <HBox minHeight="100" style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
                                              <effect>
                                                 <DropShadow />
                                              </effect>
                                           </HBox>
-                                          <HBox style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS" minHeight="100">
+                                          <HBox minHeight="100" style="-fx-background-color: #081739; -fx-background-radius: 15;" HBox.hgrow="ALWAYS">
                                              <effect>
                                                 <DropShadow />
                                              </effect>
@@ -477,7 +474,7 @@
                         </Tab>
                         <Tab text="Help and Support">
                            <content>
-                              <AnchorPane fx:id="helppane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: beige;" />
+                              <AnchorPane fx:id="helppane" minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0" style="-fx-background-color: #081028;" />
                            </content>
                         </Tab>
                      </tabs>


### PR DESCRIPTION

## 🧐 Because  

> Input: The background in Help and Support (will be known as Contact Us) panel does not match with the figma reference design. 

## 🛠 This PR  

> Input: -Changed the background color on Help and Support (Contact Us) panel.

## 🔗 Issue  

> Input: Closes #133 

## 📚 Documentation  
![image](https://github.com/user-attachments/assets/0408e2c1-1ee9-4213-869a-380932c9367f)
![image](https://github.com/user-attachments/assets/f139b113-eb01-42f4-bc5d-fdad6110766c)

## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
