### PR TITLE
[Bug] [UI] - fix position of add and sold subpane

### DIFF
--- a/src/main/java/dashboard/dashboardController.java
+++ b/src/main/java/dashboard/dashboardController.java
@@ -93,6 +93,15 @@ public class dashboardController {
         Platform.runLater(() -> {
             centerAddFormContainer(); // initial center
         });
+
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource("/confirmation/confirmation_form.fxml"));
+            Parent confirmationForm = loader.load();
+            confirmationContainer.getChildren().setAll(confirmationForm);
+            confirmationContainer.setVisible(false); // keep hidden initially
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     private void centerAddFormContainer() {
@@ -121,8 +130,15 @@ public class dashboardController {
         double parentWidth = inventorypane.getWidth();
         double parentHeight = inventorypane.getHeight();
 
-        double formWidth = confirmationContainer.getWidth() <= 0 ? confirmationContainer.getPrefWidth() : confirmationContainer.getWidth();
-        double formHeight = confirmationContainer.getHeight() <= 0 ? confirmationContainer.getPrefHeight() : confirmationContainer.getHeight();
+        confirmationContainer.applyCss();
+        confirmationContainer.layout();
+
+        double formWidth = confirmationContainer.getWidth();
+        double formHeight = confirmationContainer.getHeight();
+
+        // If width/height are 0, fallback to prefWidth
+        if (formWidth <= 0) formWidth = confirmationContainer.getPrefWidth();
+        if (formHeight <= 0) formHeight = confirmationContainer.getPrefHeight();
 
         double leftAnchor = (parentWidth - formWidth) / 2;
         double topAnchor = (parentHeight - formHeight) / 2;
@@ -133,6 +149,7 @@ public class dashboardController {
         AnchorPane.setRightAnchor(confirmationContainer, null);
         AnchorPane.setBottomAnchor(confirmationContainer, null);
     }
+
 
 
     private void styleActiveButton(Button selectedButton) {
@@ -295,17 +312,26 @@ public class dashboardController {
             Parent confirmationForm = loader.load();
 
             confirmationContainer.getChildren().setAll(confirmationForm);
+            confirmationForm.setLayoutX(0);
+            confirmationForm.setTranslateX(0);
+
             confirmationContainer.setVisible(true);
             confirmationContainer.toFront();
 
-            confirmationContainer.layout();
-            centerConfirmationContainer();
+            Platform.runLater(() -> {
+                confirmationContainer.applyCss();
+                confirmationContainer.layout();
+                centerConfirmationContainer();
+            });
+
             addFormContainer.setVisible(false);
 
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
+
+
 
     @FXML
     private void handleContinueClick() {
@@ -314,15 +340,22 @@ public class dashboardController {
             Parent confirmationForm = loader.load();
 
             confirmationContainer.getChildren().setAll(confirmationForm);
+            confirmationForm.setLayoutX(0);
+            confirmationForm.setTranslateX(0);
+
             confirmationContainer.setVisible(true);
             confirmationContainer.toFront();
 
-            confirmationContainer.layout();
-            centerConfirmationContainer();
-
+            // Wait for layout pass, then center
+            Platform.runLater(() -> {
+                confirmationContainer.applyCss();
+                confirmationContainer.layout();
+                centerConfirmationContainer();
+            });
 
         } catch (IOException e) {
             e.printStackTrace();
         }
     }
+
 }

--- a/src/main/resources/addStocks/addstocks_form.fxml
+++ b/src/main/resources/addStocks/addstocks_form.fxml
@@ -12,10 +12,8 @@
 <?import javafx.scene.text.Text?>
 
 
-<Pane prefHeight="420.0" prefWidth="375.0" style="-fx-background-color: rgba(11, 23, 57, 1); -fx-background-radius: 20;" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1">
 
-
-<Pane prefHeight="420.0" prefWidth="375.0" style="-fx-background-color: rgba(11, 23, 57, 1); -fx-background-radius: 20;" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="add_stocks.addstocksController">
+<Pane prefHeight="420.0" prefWidth="375.0" style="-fx-background-color: rgba(11, 23, 57, 1); -fx-background-radius: 20;" xmlns="http://javafx.com/javafx/23.0.1" xmlns:fx="http://javafx.com/fxml/1" >
 
    <children>
       <VBox alignment="TOP_CENTER" layoutX="22.0" layoutY="20.0" prefHeight="76.0" prefWidth="328.0">

--- a/src/main/resources/dashboard/dashboard.fxml
+++ b/src/main/resources/dashboard/dashboard.fxml
@@ -407,7 +407,7 @@
                                                    style="-fx-background-color: rgba(0, 0, 255, 0.2);"
                                                    prefHeight="420.0" prefWidth="375.0"
                                                    visible="false"/>
-                                    <AnchorPane fx:id="confirmationContainer" visible="false" prefWidth="400" prefHeight="300">
+                                    <AnchorPane fx:id="confirmationContainer" visible="false" prefWidth="300" prefHeight="200">
                                     </AnchorPane>
                                  </children>
                               </AnchorPane>


### PR DESCRIPTION

## 🧐 Because  

> Input: The add and sold confirmation pane seems a bit off the center. Fixed the position so that it's in the center, whether minimize or full screen.

## 🛠 This PR  

> Input: - Fixed the position so that it's in the center, whether minimize or full screen.

## 🔗 Issue  

> Input: Closes #152 

## 📚 Documentation  
In Add Continue (minimize):
![image](https://github.com/user-attachments/assets/588ac36c-56c0-4586-899a-c664cfc078b6)

In Add Continue (full screen):
![image](https://github.com/user-attachments/assets/e0d4d0d0-f90b-43bd-9d78-ce6d289397c1)

In Sold Continue (minimize):
![image](https://github.com/user-attachments/assets/06774c16-8de9-49b3-8461-b19afac1a50c)

In Sold Continue (full screen):
![image](https://github.com/user-attachments/assets/1dc6515f-d702-4eee-bfb0-c1cbb3b22793)

## ✅ Pull Request Requirements  
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. Leave it blank if you didn't satisfy the requirement -->
- [x] I created/referenced an issue for this specific change  
- [x] The PR title matches the linked issue title  
- [x] The `Because` section clearly explains the purpose of this PR  
- [x] The `This PR` section lists all changes in bullet points  
- [x] Linked issue(s) are referenced in the `Issue` section (if applicable)  
- [x] Documentation (screenshots/snippets) is provided for visual changes  
